### PR TITLE
Remove line ending after timestamp

### DIFF
--- a/src/CLogger.cpp
+++ b/src/CLogger.cpp
@@ -84,7 +84,6 @@ void CLogManager::Process()
 			std::time_t now_c = std::chrono::system_clock::to_time_t(msg->timestamp);
 			std::strftime(timestamp, sizeof(timestamp) / sizeof(char),
 				m_DateTimeFormat.c_str(), std::localtime(&now_c));
-			timestamp[strlen(timestamp) - 1] = '\0';
 
 			const char *loglevel_str = "<unknown>";
 			switch (msg->loglevel)

--- a/src/CLogger.cpp
+++ b/src/CLogger.cpp
@@ -84,6 +84,7 @@ void CLogManager::Process()
 			std::time_t now_c = std::chrono::system_clock::to_time_t(msg->timestamp);
 			std::strftime(timestamp, sizeof(timestamp) / sizeof(char),
 				m_DateTimeFormat.c_str(), std::localtime(&now_c));
+			timestamp[strlen(timestamp) - 1] = '\0';
 
 			const char *loglevel_str = "<unknown>";
 			switch (msg->loglevel)

--- a/src/CSampConfigReader.cpp
+++ b/src/CSampConfigReader.cpp
@@ -11,7 +11,8 @@ CSampConfigReader::CSampConfigReader()
 	{
 		string line_buffer;
 		std::getline(config_file, line_buffer);
-		line_buffer[line_buffer.length() - 1] = '\0';
+		if (line_buffer[line_buffer.size() - 1] == '\r')
+			line_buffer.resize(line_buffer.size() - 1);
 		m_FileContent.push_back(std::move(line_buffer));
 	}
 }

--- a/src/CSampConfigReader.cpp
+++ b/src/CSampConfigReader.cpp
@@ -11,6 +11,7 @@ CSampConfigReader::CSampConfigReader()
 	{
 		string line_buffer;
 		std::getline(config_file, line_buffer);
+		line_buffer[line_buffer.length() - 1] = '\0';
 		m_FileContent.push_back(std::move(line_buffer));
 	}
 }


### PR DESCRIPTION
This PR removed line ending symbol after timestamp, resolves this problem: http://forum.sa-mp.com/showpost.php?p=3695963&postcount=4

Log before:

```
[05/08/2016 10:52:27
] [INFO] SERVER: Core module init.
```

Log after:

```
[05/08/2016 10:52:27] [INFO] SERVER: Core module init.
```

P.S. Tested only on Linux.
