### PR TITLE
Three streamlining commits.

### DIFF
--- a/include/samplog/LogLevel.h
+++ b/include/samplog/LogLevel.h
@@ -18,12 +18,12 @@ enum samplog_LogLevel
 	VERBOSE = 32,
 };
 
+#ifdef __cplusplus
 inline samplog_LogLevel operator|(samplog_LogLevel a, samplog_LogLevel b)
 {
 	return static_cast<samplog_LogLevel>(static_cast<int>(a) | static_cast<int>(b));
 }
 
-#ifdef __cplusplus
 namespace samplog
 {
 	typedef samplog_LogLevel LogLevel;

--- a/include/samplog/LogLevel.h
+++ b/include/samplog/LogLevel.h
@@ -14,6 +14,8 @@ enum samplog_LogLevel
 	INFO = 2,
 	WARNING = 4,
 	ERROR = 8,
+	FATAL = 16,
+	VERBOSE = 32,
 };
 
 inline samplog_LogLevel operator|(samplog_LogLevel a, samplog_LogLevel b)

--- a/include/samplog/LogLevel.h
+++ b/include/samplog/LogLevel.h
@@ -16,6 +16,11 @@ enum samplog_LogLevel
 	ERROR = 8,
 };
 
+inline samplog_LogLevel operator|(samplog_LogLevel a, samplog_LogLevel b)
+{
+	return static_cast<samplog_LogLevel>(static_cast<int>(a) | static_cast<int>(b));
+}
+
 #ifdef __cplusplus
 namespace samplog
 {

--- a/include/samplog/PluginLogger.h
+++ b/include/samplog/PluginLogger.h
@@ -73,11 +73,6 @@ namespace samplog
 			return samplog::LogNativeCall(m_Module.c_str(), amx, params, name, params_format);
 		}
 
-		inline bool operator()(const char *msg)
-		{
-			return Log(LogLevel::INFO, msg);
-		}
-
 		inline bool operator()(LogLevel level, const char *msg)
 		{
 			return Log(level, msg);

--- a/include/samplog/PluginLogger.h
+++ b/include/samplog/PluginLogger.h
@@ -72,6 +72,27 @@ namespace samplog
 		{
 			return samplog::LogNativeCall(m_Module.c_str(), amx, params, name, params_format);
 		}
+
+		inline bool operator()(const char *msg)
+		{
+			return Log(LogLevel::INFO, msg);
+		}
+
+		inline bool operator()(LogLevel level, const char *msg)
+		{
+			return Log(level, msg);
+		}
+
+		inline bool operator()(AMX * const amx, const LogLevel level, const char *msg)
+		{
+			return Log(amx, level, msg);
+		}
+
+		inline bool operator()(AMX * const amx, cell * const params,
+			const char *name, const char *params_format)
+		{
+			return LogNativeCall(amx, params, name, params_format);
+		}
 	};
 
 	typedef CPluginLogger PluginLogger_t;

--- a/include/samplog/PluginLogger.h
+++ b/include/samplog/PluginLogger.h
@@ -53,10 +53,8 @@ namespace samplog
 		CPluginLogger& operator=(CPluginLogger &&other) = delete;
 
 	public:
-		inline bool Log(LogLevel level, const char *msg)
-		{
-			return CLogger::Log(level, msg);
-		}
+		using CLogger::Log;
+
 		bool Log(AMX * const amx, const LogLevel level, const char *msg)
 		{
 			if (!CLogger::IsLogLevel(level))


### PR DESCRIPTION
From the commit messages:

() operators for plugin logger, allows:
---

```cpp
samplog::CPluginLogger Log("fixes-plugin");

PLUGIN_EXPORT bool PLUGIN_CALL Load(void **ppData) {
	samplog::Init();
	Log(LogLevel::DEBUG, "Loaded");
	return true;
}
```

Slightly more streamlined IMHO than:

```cpp
samplog::CPluginLogger gLogger("fixes-plugin");

PLUGIN_EXPORT bool PLUGIN_CALL Load(void **ppData) {
	samplog::Init();
	gLogger.Log(LogLevel::DEBUG, "Loaded");
	return true;
}
```

Allow ORing log levels in `SetLogLevel`:
---

```cpp
logger.SetLogLevel(LogLevel::DEBUG | LogLevel::ERROR | LogLevel::INFO | LogLevel::WARNING);
```

Was previously a type mismatch warning (at least in VS), because it was cast to int by `|`.